### PR TITLE
Add missing import statement

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ import pickle
 from flask_cors import CORS
 
 import re
+import nltk
 nltk.download('stopwords')
 from nltk.corpus import stopwords
 from nltk.stem.porter import PorterStemmer


### PR DESCRIPTION
Was missing `nltk` import, caused service to immediately exit.
