### PR TITLE
Get model from model-training release artifacts

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -15,8 +15,8 @@ COPY app.py /root/
 
 # Download the models and save them to the models folder
 RUN mkdir -p /root/models \
-    && curl -L -o /root/models/c1_BoW_Sentiment_Model.pkl https://github.com/remla23-team18/model-training/raw/main/models/c1_BoW_Sentiment_Model.pkl \
-    && curl -L -o /root/models/c2_Classifier_Sentiment_Model https://github.com/remla23-team18/model-training/raw/main/models/c2_Classifier_Sentiment_Model
+    && curl -L -o /root/models/c1_BoW_Sentiment_Model.pkl https://github.com/remla23-team18/model-training/releases/download/a4/c1_BoW_Sentiment_Model.pkl \
+    && curl -L -o /root/models/c2_Classifier_Sentiment_Model https://github.com/remla23-team18/model-training/releases/download/a4/c2_Classifier_Sentiment_Model
 
 RUN mkdir -p /root/scripts \
     && curl -L -o /root/scripts/preprocess.py https://github.com/remla23-team18/model-training/raw/main/preprocess.py


### PR DESCRIPTION
The structure of `model-training` has changed, and the `docker` build was relying on the previous structure.

This PR updates the `dockerfile` to reflect to the new structure.
